### PR TITLE
fix(kleinanzeigen): hide pur (#31), harden share-url fingerprint and bump version to 2026.38.3 (#43)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,11 @@
 [versions]
 morphe-patcher = "1.3.3"
 #noinspection GradleDependency
+morphe-patches-library = "1.2.0" # built against morphe-patcher 1.3.3
 smali = "b6365a84f4"
 gson = "2.13.2"
 
 [libraries]
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+morphe-patcher = { module = "app.morphe:morphe-patcher", version.ref = "morphe-patcher" }
+morphe-patches-library = { module = "app.morphe:morphe-patches-library", version.ref = "morphe-patches-library" }

--- a/patches/build.gradle.kts
+++ b/patches/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
 dependencies {
     // Used by JsonGenerator.
     implementation(libs.gson)
+    implementation(libs.morphe.patches.library)
 }
 
 tasks {

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/ads/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/ads/HideAdsPatch.kt
@@ -10,9 +10,7 @@ private val COMPAT = Compatibility(
     packageName = "com.ebay.kleinanzeigen",
     appIconColor = 0x2EAD33,
     targets = listOf(
-        AppTarget(version = "2026.16.1"),
-        AppTarget(version = "2026.14.2"),
-        AppTarget(version = "2026.14.0"),
+        AppTarget(version = "2026.30.0"),
     ),
 )
 

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/ads/HideAdsPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/ads/HideAdsPatch.kt
@@ -9,9 +9,7 @@ private val COMPAT = Compatibility(
     name = "Kleinanzeigen",
     packageName = "com.ebay.kleinanzeigen",
     appIconColor = 0x2EAD33,
-    targets = listOf(
-        AppTarget(version = "2026.30.0"),
-    ),
+    targets = listOf(AppTarget(version = "2026.36.0")),
 )
 
 @Suppress("unused")

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/Fingerprints.kt
@@ -1,16 +1,22 @@
 package app.docbt.patched_up.kleinanzeigen.hidepur
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.methodCall
+import app.morphe.patches.all.misc.resources.ResourceType
+import app.morphe.patches.all.misc.resources.resourceLiteral
 
-// setupSections (2026.9.0) / q (2026.12.0) in SettingsAndHelpFragment:
-// parameter p7 = showAdFreeSubscription (bool). The single IF_EQZ p7 controls
-// whether the Pur section container is VISIBLE or GONE.
-// SettingsAndHelpFragment is never obfuscated — stable across versions.
+// Resolves the Pur title string's ID at patch time from the current APK's
+// own res/values/public.xml, instead of a fixed value which might change each APK release.
+// So it self-corrects if aapt2 ever renumbers ka_gbl_pur between APK releases.
+//
+// filters[0] identifies the ROW (the Pur entry specifically, via its title
+// resource); filters[1] identifies which of the ~14 setVisibility(I) calls
+// in this method belongs to that row. Both are required — resourceLiteral
+// alone only proves we're in the right method, not which instruction to patch.
 internal object SetupSectionsPurFingerprint : Fingerprint(
-    custom = { method, classDef ->
-        classDef.type == "Lebk/ui/preferences/settings/settings_and_help/SettingsAndHelpFragment;" &&
-        !method.name.startsWith("access\$") &&
-        method.parameterTypes.count { it == "Z" } >= 5 &&
-        method.parameterTypes.any { it == "Ljava/lang/String;" }
-    },
+    definingClass = "Lebk/ui/preferences/settings/settings_and_help/SettingsAndHelpFragment;",
+    filters = listOf(
+        resourceLiteral(ResourceType.STRING, "ka_gbl_pur"),
+        methodCall(smali = "Landroid/view/View;->setVisibility(I)V"),
+    ),
 )

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/Fingerprints.kt
@@ -1,22 +1,14 @@
 package app.docbt.patched_up.kleinanzeigen.hidepur
 
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.methodCall
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
 
-// Resolves the Pur title string's ID at patch time from the current APK's
-// own res/values/public.xml, instead of a fixed value which might change each APK release.
-// So it self-corrects if aapt2 ever renumbers ka_gbl_pur between APK releases.
-//
-// filters[0] identifies the ROW (the Pur entry specifically, via its title
-// resource); filters[1] identifies which of the ~14 setVisibility(I) calls
-// in this method belongs to that row. Both are required — resourceLiteral
-// alone only proves we're in the right method, not which instruction to patch.
-internal object SetupSectionsPurFingerprint : Fingerprint(
-    definingClass = "Lebk/ui/preferences/settings/settings_and_help/SettingsAndHelpFragment;",
+// Anchors on the ka_gbl_pur string resource to locate the eligibility check
+// that gates whether Pur is added to the Compose settings list. No class
+// constraint: the containing class is an R8-merged utility with no stable name.
+internal object HidePurEligibilityFingerprint : Fingerprint(
     filters = listOf(
         resourceLiteral(ResourceType.STRING, "ka_gbl_pur"),
-        methodCall(smali = "Landroid/view/View;->setVisibility(I)V"),
     ),
 )

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/HidePurPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/HidePurPatch.kt
@@ -5,13 +5,14 @@ import app.morphe.patcher.patch.AppTarget
 import app.morphe.patcher.patch.Compatibility
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 private val COMPAT = Compatibility(
     name = "Kleinanzeigen",
     packageName = "com.ebay.kleinanzeigen",
     appIconColor = 0x2EAD33,
-    targets = listOf(AppTarget(version = "2026.30.0")),
+    targets = listOf(AppTarget(version = "2026.36.0")),
 )
 
 @Suppress("unused")
@@ -20,29 +21,27 @@ val hidePurPatch = bytecodePatch(
     description = "Hides the Pur ad-free subscription option from the settings menu.",
 ) {
     compatibleWith(COMPAT)
-
-    // resourceMappingPatch is required whenever a fingerprint uses resourceLiteral(): this patch builds
-    // the resource-name -> id lookup table (from public.xml) that the filter
-    // reads at match time. Omitting this dependency leaves the table empty and
-    // the fingerprint will fail to match with no obvious error pointing here.
     dependsOn(resourceMappingPatch)
 
     execute {
-        SetupSectionsPurFingerprint.let {
-            // instructionMatches[1] = the second filter above (the setVisibility
-            // call for the Pur row specifically, not just any setVisibility call).
-            val setVisibilityMatch = it.instructionMatches[1]
-            val invoke = setVisibilityMatch.getInstruction<FiveRegisterInstruction>()
-            val visibilityArgRegister = invoke.registerD // the `int` visibility arg register, not the View receiver
+        HidePurEligibilityFingerprint.let {
+            val method = it.method
+            val instructions = method.implementation!!.instructions.toList()
+            val literalIndex = it.instructionMatches[0].index
 
-            // const/16, not const/4: const/4's literal is a signed 4-bit value
-            // (range -8..7), and View.GONE = 8 overflows that by exactly one.
-            // Using const/4 here compiles to invalid smali and fails silently
-            // downstream as "Collection is empty" during instruction assembly.
-            it.method.addInstructions(
-                setVisibilityMatch.index,
-                "const/16 v$visibilityArgRegister, 0x8", // View.GONE
-            )
+            // The Pur row is only appended inside `if (eligible) { list.add(...) }`.
+            // Walk backward from the ka_gbl_pur reference to find that specific
+            // gate, not forward from the top of the method.
+            val branchIndex = (literalIndex downTo 0).first { i ->
+                instructions[i].opcode == Opcode.IF_EQZ || instructions[i].opcode == Opcode.IF_NEZ
+            }
+            val gateReg = (instructions[branchIndex] as OneRegisterInstruction).registerA
+
+            // Force the gate to always take the "ineligible" branch, regardless of
+            // whether the compiler emitted IF_EQZ or IF_NEZ for this check.
+            val forceValue = if (instructions[branchIndex].opcode == Opcode.IF_EQZ) "0x0" else "0x1"
+
+            method.addInstructions(branchIndex, "const/4 v$gateReg, $forceValue")
         }
     }
 }

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/HidePurPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/hidepur/HidePurPatch.kt
@@ -1,21 +1,17 @@
 package app.docbt.patched_up.kleinanzeigen.hidepur
 
-import app.morphe.patcher.extensions.InstructionExtensions
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.AppTarget
 import app.morphe.patcher.patch.Compatibility
 import app.morphe.patcher.patch.bytecodePatch
-import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 
 private val COMPAT = Compatibility(
     name = "Kleinanzeigen",
     packageName = "com.ebay.kleinanzeigen",
     appIconColor = 0x2EAD33,
-    targets = listOf(
-        AppTarget(version = "2026.16.1"),
-        AppTarget(version = "2026.14.2"),
-        AppTarget(version = "2026.14.0"),
-    ),
+    targets = listOf(AppTarget(version = "2026.30.0")),
 )
 
 @Suppress("unused")
@@ -25,23 +21,28 @@ val hidePurPatch = bytecodePatch(
 ) {
     compatibleWith(COMPAT)
 
+    // resourceMappingPatch is required whenever a fingerprint uses resourceLiteral(): this patch builds
+    // the resource-name -> id lookup table (from public.xml) that the filter
+    // reads at match time. Omitting this dependency leaves the table empty and
+    // the fingerprint will fail to match with no obvious error pointing here.
+    dependsOn(resourceMappingPatch)
+
     execute {
-        with(InstructionExtensions) {
-            // setupSections() (2026.9.0) / q() (2026.12.0) in SettingsAndHelpFragment:
-            // p7 = showAdFreeSubscription. The single IF_EQZ p7 sends to GONE when false,
-            // VISIBLE when true. Forcing vReg = 0 before IF_EQZ always hides the Pur entry.
-            val method = SetupSectionsPurFingerprint.method
-            var ifEqzIndex = -1
-            var showAdFreeReg = -1
-            for ((i, instr) in method.implementation!!.instructions.withIndex()) {
-                if (instr.opcode == Opcode.IF_EQZ) {
-                    ifEqzIndex = i
-                    showAdFreeReg = (instr as OneRegisterInstruction).registerA
-                    break
-                }
-            }
-            check(ifEqzIndex != -1) { "IF_EQZ not found in setupSections/q" }
-            method.addInstruction(ifEqzIndex, "const/4 v$showAdFreeReg, 0x0")
+        SetupSectionsPurFingerprint.let {
+            // instructionMatches[1] = the second filter above (the setVisibility
+            // call for the Pur row specifically, not just any setVisibility call).
+            val setVisibilityMatch = it.instructionMatches[1]
+            val invoke = setVisibilityMatch.getInstruction<FiveRegisterInstruction>()
+            val visibilityArgRegister = invoke.registerD // the `int` visibility arg register, not the View receiver
+
+            // const/16, not const/4: const/4's literal is a signed 4-bit value
+            // (range -8..7), and View.GONE = 8 overflows that by exactly one.
+            // Using const/4 here compiles to invalid smali and fails silently
+            // downstream as "Collection is empty" during instruction assembly.
+            it.method.addInstructions(
+                setVisibilityMatch.index,
+                "const/16 v$visibilityArgRegister, 0x8", // View.GONE
+            )
         }
     }
 }

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/Fingerprints.kt
@@ -1,23 +1,67 @@
 package app.docbt.patched_up.kleinanzeigen.sharetracking
 
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.patch.PatchException
+import com.android.tools.smali.dexlib2.iface.ClassDef
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
-// e.h() — builds the VIP ad share URL, switches utm_source by target app.
-// "sharesheet" is the stable default source string (used for generic share sheet).
-internal object ShareUrlBuilderFingerprint : Fingerprint(
-    strings = listOf("sharesheet"),
-    custom = { _, classDef -> classDef.type == "Lebk/ui/vip/compose/content/e;" },
-)
+// Anchor strings: appear together in the share-target switch statement.
+// Using several co-occurring strings instead of just "sharesheet" avoids
+// false-positive matches against unrelated code elsewhere in the merged
+// multi-dex APK that might also contain the word "sharesheet" on its own.
+private val ANCHOR_STRINGS = setOf("sharesheet", "com.whatsapp", "com.pinterest", "com.facebook.orca")
+
+// True if any method in this class references all of ANCHOR_STRINGS
+// (not necessarily the same method — they live in different switch
+// branches of the same method in practice, but we don't rely on that).
+private fun ClassDef.containsAnchorStrings(): Boolean {
+    val remaining = ANCHOR_STRINGS.toMutableSet()
+    for (method in methods) {
+        val instructions = method.implementation?.instructions ?: continue
+        for (instruction in instructions) {
+            val ref = (instruction as? ReferenceInstruction)?.reference as? StringReference ?: continue
+            remaining.remove(ref.string)
+        }
+        if (remaining.isEmpty()) return true
+    }
+    return remaining.isEmpty()
+}
 
 // e.i(url, source) — appends UTM params to a URL and returns the result.
-// Called by h() for ad sharing and directly for store sharing.
-// Signature: (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
-// Identified by: same class as h(), returns String, takes exactly 2 String parameters.
+// Class itself may be merged into an unrelated library namespace (e.g. OkHttp)
+// by R8, and its name/package can change between versions — do not lock to type.
+// Instead: identify the class via ANCHOR_STRINGS, then require the matched
+// method to be the unique (String, String) -> String method in that class.
 internal object ShareUrlParamBuilderFingerprint : Fingerprint(
     custom = { method, classDef ->
-        classDef.type == "Lebk/ui/vip/compose/content/e;" &&
-        method.returnType == "Ljava/lang/String;" &&
-        method.parameterTypes.size == 2 &&
-        method.parameterTypes.all { it.toString() == "Ljava/lang/String;" }
+        val isRightShape =
+            method.returnType == "Ljava/lang/String;" &&
+            method.parameterTypes.size == 2 &&
+            method.parameterTypes.all { it.toString() == "Ljava/lang/String;" }
+
+        if (!isRightShape || !classDef.containsAnchorStrings()) {
+            false
+        } else {
+            val shapeMatches = classDef.methods.filter { m ->
+                m.returnType == "Ljava/lang/String;" &&
+                m.parameterTypes.size == 2 &&
+                m.parameterTypes.all { it.toString() == "Ljava/lang/String;" }
+            }
+            // The PatchException below is intentional and not just defensive boilerplate:
+            // if a future app version adds a second (String, String) -> String method to
+            // this class, we want the build to fail loudly with a clear message, rather
+            // than silently patching whichever method happens to be listed first — the
+            // exact class of bug that caused the original Hide Pur regression this patch
+            // set was built to avoid repeating.
+            if (shapeMatches.size != 1) {
+                throw PatchException(
+                    "Expected exactly 1 method matching (String, String) -> String in " +
+                    "${classDef.type}, but found ${shapeMatches.size}" +
+                    if (shapeMatches.isEmpty()) "." else ": ${shapeMatches.joinToString { it.name }}."
+                )
+            }
+            true
+        }
     },
 )

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/RemoveTrackingParamsPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/RemoveTrackingParamsPatch.kt
@@ -10,9 +10,7 @@ private val COMPAT = Compatibility(
     packageName = "com.ebay.kleinanzeigen",
     appIconColor = 0x2EAD33,
     targets = listOf(
-        AppTarget(version = "2026.16.1"),
-        AppTarget(version = "2026.14.2"),
-        AppTarget(version = "2026.14.0"),
+        AppTarget(version = "2026.30.0"),
     ),
 )
 

--- a/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/RemoveTrackingParamsPatch.kt
+++ b/patches/src/main/kotlin/app/docbt/patched_up/kleinanzeigen/sharetracking/RemoveTrackingParamsPatch.kt
@@ -9,9 +9,7 @@ private val COMPAT = Compatibility(
     name = "Kleinanzeigen",
     packageName = "com.ebay.kleinanzeigen",
     appIconColor = 0x2EAD33,
-    targets = listOf(
-        AppTarget(version = "2026.30.0"),
-    ),
+    targets = listOf(AppTarget(version = "2026.36.0")),
 )
 
 @Suppress("unused")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,5 +17,5 @@ pluginManagement {
 }
 
 plugins {
-    id("app.morphe.patches") version "1.2.0"
+    id("app.morphe.patches") version "1.3.0"
 }

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,4 @@
 {
   "googleNews": "5.163.0.947799485",
-  "kleinanzeigen": "2026.16.1"
+  "kleinanzeigen": "2026.30.0"
 }


### PR DESCRIPTION
**Edit 2026-09-05:**

The Hide-Pur patch stopped working for versions > 2026.30.0 as the developers completely changed the underlying technology of the settings menu. So I had to update the patch. I also bumped the version to the newest 2026.36.0.

**Original message from 2026-07-27:**

_First things first:_

_Although I have a bit of experience in writing Python code, I'm very new to Kotlin, Patching APKs and the Morphe project in whole. So if there is any big mistake from my side, I apologize in advance._

_But I really like the Morphe project and also your patches, so I wanted to contribute and give something back. As I'm not that familiar with APKs and Kotlin, I mainly use Claude AI to help me fixing the patches. Then I double checked the logic of the patches that Claude offered me and tested it thoroughly._


fix: resolve Pur visibility toggle by content instead of position

Fixes #31 (Pur still visible after patching). The previous fingerprint identified the target row by parameter shape (`>= 5 boolean params`) and patched the *first* `IF_EQZ` instruction found in the method — neither was actually tied to the Pur row specifically, so both broke silently once the compiled method signature shifted in a later app release.

Rewrites the fingerprint to anchor on content instead of shape/position:

- Matches via `resourceLiteral(ResourceType.STRING, "ka_gbl_pur")`, resolved from the APK's own resource table at patch time rather than hardcoded.
- Identifies the specific `setVisibility(I)V` call belonging to the Pur row, not just the first one in the method (there are ~14, one per settings row).
- Patches the visibility argument directly to `View.GONE` instead of intercepting the boolean flag that gates it, so it no longer depends on which register or branch opcode (`IF_EQZ`/`IF_NEZ`) the compiler happens to emit.

refactor: harden share-url fingerprint against the same failure mode

Applies the same anchoring fix to
`ShareUrlParamBuilderFingerprint`, which previously locked onto an obfuscated class type name directly (`Lebk/ui/vip/compose/content/e;`). Now identifies the class by co-occurring string literals from the share-target switch statement, and explicitly throws if more than one method matches the target shape instead of silently taking the first match. "Remove Tracking parameters" stopped working for me in some newer versions, that's why I changed the design of the fingerprint to make it more robust.

feat: bump supported Kleinanzeigen version to 2026.30.0

Closes #43 (support newer Kleinanzeigen versions — previously pinned to 2026.16.1). Hide Pur, Hide Ads, and Remove Tracking Params now all target 2026.30.0. Older `AppTarget` entries were dropped rather than kept alongside

chore: bump app.morphe.patches to 1.3.0 and add morphe-patches-library

Needed for `resourceLiteral`/`resourceMappingPatch`, used by the Hide Pur fix above. Bumped `app.morphe.patches` 1.2.0 -> 1.3.0 (Kotlin 2.0.21 -> 2.2.0) and added `morphe-patches-library` 1.2.0, the release
confirmed built against `morphe-patcher 1.3.3`.

Deliberately stayed on plugin 1.3.0 rather than 1.3.1+, which also bumps AGP 8.13.2 -> 9.1.0 — kept this change scoped to the Kotlin version bump only, since that's the only piece actually required here.

Re-ran the full Google News patch set against the updated toolchain to confirm the plugin bump doesn't regress anything outside this PR's scope — all patches there still build and match correctly.

I've verified the Kleinanzeigen patches against several versions between 2026.14.2 and the newest 2026.30.0. All the versions worked, so in the AppTarget we could also include various older versions if you like. I'm not sure what the practice is here. Only target the newest version? The 3 newest versions? Several versions? Feel free to give a suggestion.

Closes #31
Closes #43